### PR TITLE
Adds support for void elements

### DIFF
--- a/ir-clone.js
+++ b/ir-clone.js
@@ -1,3 +1,5 @@
+var voidMap = require("./void-map");
+
 var REG_ESCAPE_ALL = /[<>&]/g;
 var REG_ESCAPE_PRESERVE_ENTITIES = /[<>]|&(?:#?[a-zA-Z0-9]+;)?/g;
 
@@ -40,7 +42,7 @@ function* serialize(rootNode) {
 					}
 					yield ">";
 
-					if(!node.firstChild && node.nodeType === 1) {
+					if(!node.firstChild && node.nodeType === 1 && !isVoid(node)) {
 						yield "</" + node.nodeName.toLowerCase() + ">";
 					}
 					break;
@@ -80,7 +82,7 @@ function* serialize(rootNode) {
 			depth--;
 			skip = true;
 
-			if(node.nodeType === 1) {
+			if(node.nodeType === 1 && !isVoid(node)) {
 				yield "</" + node.nodeName.toLowerCase() + ">";
 			}
 		}
@@ -125,6 +127,10 @@ function escapeText(value, escapeAll) {
 
 function isMetadataTag (elem) {
 	return !!elem && metadataContentTags[elem.nodeName.toLowerCase()];
+}
+
+function isVoid(element) {
+	return voidMap[element.nodeName] === true;
 }
 
 exports.serialize = serialize;

--- a/test/ir-clone-test.js
+++ b/test/ir-clone-test.js
@@ -64,3 +64,15 @@ QUnit.test("Escapes attributes", function() {
 	var expected = "<!DOCTYPE html><html><head><title>test</title></head><body><iframe srcdoc=\"<html><head><title>Some title</title></head><body class=&quot;open&quot;><h1>Hello world</h1></body></html>\"></iframe></body></html>";
 	QUnit.equal(html, expected);
 });
+
+QUnit.test("Does not close void elements", function() {
+	var doc = createDocument();
+	doc.head.appendChild(doc.createElement("meta"));
+	doc.head.appendChild(doc.createElement("link"));
+	doc.body.appendChild(doc.createElement("div"));
+	doc.body.appendChild(doc.createElement("input"));
+
+	var html = cloneUtils.serializeToString(doc);
+	var expected = "<!DOCTYPE html><html><head><title>test</title><meta><link></head><body><div></div><input></body></html>";
+	QUnit.equal(html, expected);
+});

--- a/void-map.js
+++ b/void-map.js
@@ -1,0 +1,18 @@
+module.exports = {
+  AREA: true,
+  BASE: true,
+  BR: true,
+  COL: true,
+  COMMAND: true,
+  EMBED: true,
+  HR: true,
+  IMG: true,
+  INPUT: true,
+  KEYGEN: true,
+  LINK: true,
+  META: true,
+  PARAM: true,
+  SOURCE: true,
+  TRACK: true,
+  WBR: true
+};


### PR DESCRIPTION
This adds support for void elements (without closing tags) like `<link>`
and `<input>`. Closes #4