### PR TITLE
Don't add spacing on empty textnodes

### DIFF
--- a/ir-clone.js
+++ b/ir-clone.js
@@ -53,7 +53,7 @@ function* serialize(rootNode) {
 					}
 
 					if (isMetadataTag(node.parentNode)) {
-						yield giveSpace(node.nodeValue);
+						yield node.nodeValue;
 					} else {
 						yield giveSpace(escapeText(node.nodeValue));
 					}

--- a/test/ir-clone-test.js
+++ b/test/ir-clone-test.js
@@ -79,7 +79,6 @@ QUnit.test("Does not close void elements", function() {
 
 QUnit.test("Empty TextNodes are given space", function() {
 	var doc = createDocument();
-	var el = doc.createElement("div");
 
 	doc.body.appendChild(doc.createTextNode(""));
 	doc.body.appendChild(doc.createTextNode(""));
@@ -87,5 +86,17 @@ QUnit.test("Empty TextNodes are given space", function() {
 
 	var html = cloneUtils.serializeToString(doc);
 	var expected = "<!DOCTYPE html><html><head><title>test</title></head><body> <!--__DONEJS-SEP__--> <!--__DONEJS-SEP__--> </body></html>";
+	QUnit.equal(html, expected);
+});
+
+
+QUnit.test("Script tags with an empty TextNode are not given space", function() {
+	var doc = createDocument();
+	var script = doc.createElement("script");
+	script.appendChild(doc.createTextNode(""));
+	doc.body.appendChild(script);
+
+	var html = cloneUtils.serializeToString(doc);
+	var expected = "<!DOCTYPE html><html><head><title>test</title></head><body><script></script></body></html>";
 	QUnit.equal(html, expected);
 });


### PR DESCRIPTION
When they are the children of "metadata" tags such as scripts.