### PR TITLE
Prefer textNode.data over nodeValue

### DIFF
--- a/ir-clone.js
+++ b/ir-clone.js
@@ -9,6 +9,10 @@ var metadataContentTags = {
     template: true
 };
 
+function tnValue(node) {
+	return node.data != null ? node.data : node.nodeValue;
+}
+
 function* serialize(rootNode) {
 	var node = rootNode;
 	var prev = node;
@@ -53,9 +57,9 @@ function* serialize(rootNode) {
 					}
 
 					if (isMetadataTag(node.parentNode)) {
-						yield node.nodeValue;
+						yield tnValue(node);
 					} else {
-						yield giveSpace(escapeText(node.nodeValue));
+						yield giveSpace(escapeText(tnValue(node)));
 					}
 					break;
 				// Comments

--- a/test/ir-clone-test.js
+++ b/test/ir-clone-test.js
@@ -100,3 +100,16 @@ QUnit.test("Script tags with an empty TextNode are not given space", function() 
 	var expected = "<!DOCTYPE html><html><head><title>test</title></head><body><script></script></body></html>";
 	QUnit.equal(html, expected);
 });
+
+QUnit.test("Prefer TextNode::data over nodeValue", function() {
+	var doc = createDocument();
+	var tn = doc.createTextNode("value");
+	Object.defineProperty(tn, "nodeValue", {
+		value: undefined
+	});
+	doc.body.appendChild(tn);
+
+	var html = cloneUtils.serializeToString(doc);
+	var expected = "<!DOCTYPE html><html><head><title>test</title></head><body>value</body></html>";
+	QUnit.equal(html, expected);
+});


### PR DESCRIPTION
.data is preferred by jsdom, so use that if it exists.