### PR TITLE
Move styles to the end of the body

### DIFF
--- a/test/frame-test.js
+++ b/test/frame-test.js
@@ -62,4 +62,21 @@ QUnit.test("data-incrementally-rendered attr added", function(assert) {
 	assert.equal(doc.documentElement.dataset.incrementallyRendered, "");
 });
 
-//doc.documentElement.setAttribute("data-incrementally-rendered", "");
+QUnit.test("Blocking link tags are moved to the bottom of the body", function(assert) {
+	let doc = createDocument();
+	
+	let link = doc.createElement("link");
+	link.rel = "stylesheet";
+	link.href = "http://example.com/foo.css";
+	doc.head.appendChild(link);
+
+	cloneUtils.injectFrame(doc, {
+		reattachScript: "console.log('hello world');",
+		streamUrl: "http://example.com/instr",
+		preload: true
+	});
+
+	let last = doc.head.lastChild;
+	assert.notEqual(last.nodeName, "LINK", "link not in the head");
+	assert.equal(doc.body.lastChild.nodeName, "LINK", "link is now in the body");
+});


### PR DESCRIPTION
This moves styles to the end of the body, so that they do not block the
iframe from loading and executing.